### PR TITLE
Key expiration not correctly set in the first request

### DIFF
--- a/RedisSessionProvider/RedisSessionStateStoreProvider.cs
+++ b/RedisSessionProvider/RedisSessionStateStoreProvider.cs
@@ -382,12 +382,6 @@
 
             IDatabase redisConn = rConnWrap.GetConnection();
 
-            // always refresh the timeout of the session hash
-            redisConn.KeyExpire(
-                currentRedisHashId,
-                expirationTimeout,
-                CommandFlags.FireAndForget);
-
             if (setItems.Count > 0)
             {
                 HashEntry[] writeItems = setItems.ToArray();
@@ -422,6 +416,12 @@
                         currentRedisHashId);
                 }
             }
+
+            // always refresh the timeout of the session hash
+            redisConn.KeyExpire(
+                currentRedisHashId,
+                expirationTimeout,
+                CommandFlags.FireAndForget);
         }
 
         /// <summary>

--- a/RedisSessionProviderUnitTests/Integration/ExpirationTests.cs
+++ b/RedisSessionProviderUnitTests/Integration/ExpirationTests.cs
@@ -1,0 +1,73 @@
+﻿using Moq;
+using RedisSessionProvider.Config;
+using StackExchange.Redis;
+using System.Web;
+
+namespace RedisSessionProviderUnitTests.Integration
+{
+    using NUnit.Framework;
+    using RedisSessionProvider;
+    using System;
+
+
+    [TestFixture]
+    public class ExpirationTests
+    {
+        private static string REDIS_SERVER = "192.168.0.12:6379";
+        private static int REDIS_DB = 13;
+        private static TimeSpan TIMEOUT = new TimeSpan(1, 0, 0);
+        private static string SESSION_ID = "SESSION_ID";
+
+        static ConfigurationOptions _redisConfigOpts;
+
+        private IDatabase db;
+
+        [SetUp]
+        public void OnBeforeTestExecute()
+        {
+            _redisConfigOpts = ConfigurationOptions.Parse(REDIS_SERVER);
+            RedisConnectionConfig.GetSERedisServerConfigDbIndex = @base => new Tuple<string, int, ConfigurationOptions>(
+                "SessionConnection", REDIS_DB, _redisConfigOpts);
+            RedisSessionConfig.SessionTimeout = TIMEOUT;
+
+            // StackExchange Redis client
+            ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(REDIS_SERVER);
+            db = redis.GetDatabase(REDIS_DB);
+        }
+
+        [Test]
+        public void ExpirationSet_AsExpected()
+        {
+
+            var mockHttpContext = new Mock<HttpContextBase>();
+            var mockHttpRequest = new Mock<HttpRequestBase>();
+            mockHttpRequest.Setup(x => x.Cookies).Returns(new HttpCookieCollection()
+                                                          {
+                                                              new HttpCookie(RedisSessionConfig.SessionHttpCookieName, SESSION_ID)
+                                                          });
+            mockHttpContext.Setup(x => x.Request).Returns(mockHttpRequest.Object);
+
+
+            using (var sessAcc = new RedisSessionAccessor(mockHttpContext.Object))
+            {
+                sessAcc.Session["MyKey"] = DateTime.UtcNow;
+            }
+
+            // Assert directly using Stackexchange.Redis
+            var ttl = db.KeyTimeToLive(SESSION_ID);
+            
+            // We should not have a null here
+            Assert.IsNotNull(ttl);
+            Assert.IsTrue(ttl.Value <= TIMEOUT);
+            Assert.IsTrue(ttl.Value.Minutes > 0);
+
+        }
+
+        [TearDown]
+        public void OnAfterTestExecute()
+        {
+            // cleanup
+            db.KeyDelete(SESSION_ID);
+        }
+    }
+}

--- a/RedisSessionProviderUnitTests/RedisSessionProviderUnitTests.csproj
+++ b/RedisSessionProviderUnitTests/RedisSessionProviderUnitTests.csproj
@@ -51,6 +51,9 @@
     <Reference Include="NUnit.VisualStudio.TestAdapter">
       <HintPath>..\packages\NUnitTestAdapter.1.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
     </Reference>
+    <Reference Include="StackExchange.Redis">
+      <HintPath>..\packages\StackExchange.Redis.1.0.273\lib\net45\StackExchange.Redis.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -62,6 +65,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Integration\ExpirationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RedisJSONSerializerTests\SeriousTests.cs" />
     <Compile Include="RedisSessionStateItemCollectionTests\MultiThreadedTests.cs" />

--- a/RedisSessionProviderUnitTests/packages.config
+++ b/RedisSessionProviderUnitTests/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="1.0" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.273" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is my first pull request, so sorry in advance for any thing I did the wrong way.

We are using this provider on our system and we found that in some cases a sessions with a null TTL were being created on redis and never deleted. 
It seems that the KeyExpire is not correctly set on the first request (and if the key is never requested again). 
It is easily fixed only moving the keyExpire instruction after the Hashset. I added a Integration Test to the test project to demonstrate (and test) the problem.
