### PR TITLE
Session keys should be case-INsensitive to match default ASP.NET behavior

### DIFF
--- a/RedisSessionProvider/LocalSharedSessionDictionary.cs
+++ b/RedisSessionProvider/LocalSharedSessionDictionary.cs
@@ -22,7 +22,7 @@
     /// </summary>
     public class LocalSharedSessionDictionary
     {
-        //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+        // To match ASP.NET behavior, dictionaries should match keys case insensitively
         private static ConcurrentDictionary<string, SessionAndRefCount> localCache =
             new ConcurrentDictionary<string, SessionAndRefCount>(StringComparer.InvariantCultureIgnoreCase);
 

--- a/RedisSessionProvider/LocalSharedSessionDictionary.cs
+++ b/RedisSessionProvider/LocalSharedSessionDictionary.cs
@@ -22,8 +22,9 @@
     /// </summary>
     public class LocalSharedSessionDictionary
     {
+        //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
         private static ConcurrentDictionary<string, SessionAndRefCount> localCache =
-            new ConcurrentDictionary<string, SessionAndRefCount>();
+            new ConcurrentDictionary<string, SessionAndRefCount>(StringComparer.InvariantCultureIgnoreCase);
 
         private static SysTimer cacheFreshnessTimer;
 

--- a/RedisSessionProvider/RedisSessionStateItemCollection.cs
+++ b/RedisSessionProvider/RedisSessionStateItemCollection.cs
@@ -82,7 +82,7 @@
                 numItems = redisHashData.Count;
             }
 
-            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            // To match ASP.NET behavior, dictionaries should match keys case insensitively
             this.Items = new ConcurrentDictionary<string, object>(concLevel, numItems, StringComparer.InvariantCultureIgnoreCase);
             this.SerializedRawData = new ConcurrentDictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             if (redisHashData != null)
@@ -102,7 +102,7 @@
                 }
             }
 
-            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            // To match ASP.NET behavior, dictionaries should match keys case insensitively
             this.ChangedKeysDict = new ConcurrentDictionary<string, ActionAndValue>(StringComparer.InvariantCultureIgnoreCase);
 
             if (byteDataTotal != 0 && !string.IsNullOrEmpty(redisConnName) &&
@@ -143,7 +143,7 @@
                 numItems = redisHashData.Length;
             }
 
-            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            // To match ASP.NET behavior, dictionaries should match keys case insensitively
             this.Items = new ConcurrentDictionary<string, object>(concLevel, numItems, StringComparer.InvariantCultureIgnoreCase);
             this.SerializedRawData = new ConcurrentDictionary<string, string>(concLevel, numItems, StringComparer.InvariantCultureIgnoreCase);
             if (redisHashData != null)
@@ -166,7 +166,7 @@
                 }
             }
 
-            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            // To match ASP.NET behavior, dictionaries should match keys case insensitively
             this.ChangedKeysDict = new ConcurrentDictionary<string, ActionAndValue>(StringComparer.InvariantCultureIgnoreCase);
 
             if (byteDataTotal != 0 && !string.IsNullOrEmpty(redisConnName) &&
@@ -384,7 +384,7 @@
                 }
             }
 
-            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            // To match ASP.NET behavior, dictionaries should match keys case insensitively
             return new ConcurrentDictionary<string, object>(StringComparer.InvariantCultureIgnoreCase).GetEnumerator();
         }
 

--- a/RedisSessionProvider/RedisSessionStateItemCollection.cs
+++ b/RedisSessionProvider/RedisSessionStateItemCollection.cs
@@ -82,8 +82,9 @@
                 numItems = redisHashData.Count;
             }
 
-            this.Items = new ConcurrentDictionary<string, object>(concLevel, numItems);
-            this.SerializedRawData = new ConcurrentDictionary<string, string>();
+            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            this.Items = new ConcurrentDictionary<string, object>(concLevel, numItems, StringComparer.InvariantCultureIgnoreCase);
+            this.SerializedRawData = new ConcurrentDictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             if (redisHashData != null)
             {
                 foreach (var sessDataEntry in redisHashData)
@@ -101,7 +102,8 @@
                 }
             }
 
-            this.ChangedKeysDict = new ConcurrentDictionary<string, ActionAndValue>();
+            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            this.ChangedKeysDict = new ConcurrentDictionary<string, ActionAndValue>(StringComparer.InvariantCultureIgnoreCase);
 
             if (byteDataTotal != 0 && !string.IsNullOrEmpty(redisConnName) &&
                 RedisConnectionConfig.LogRedisSessionSize != null)
@@ -141,8 +143,9 @@
                 numItems = redisHashData.Length;
             }
 
-            this.Items = new ConcurrentDictionary<string, object>(concLevel, numItems);
-            this.SerializedRawData = new ConcurrentDictionary<string, string>(concLevel, numItems);
+            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            this.Items = new ConcurrentDictionary<string, object>(concLevel, numItems, StringComparer.InvariantCultureIgnoreCase);
+            this.SerializedRawData = new ConcurrentDictionary<string, string>(concLevel, numItems, StringComparer.InvariantCultureIgnoreCase);
             if (redisHashData != null)
             {
                 foreach (var sessDataEntry in redisHashData)
@@ -163,7 +166,8 @@
                 }
             }
 
-            this.ChangedKeysDict = new ConcurrentDictionary<string, ActionAndValue>();
+            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            this.ChangedKeysDict = new ConcurrentDictionary<string, ActionAndValue>(StringComparer.InvariantCultureIgnoreCase);
 
             if (byteDataTotal != 0 && !string.IsNullOrEmpty(redisConnName) &&
                 RedisConnectionConfig.LogRedisSessionSize != null)
@@ -380,7 +384,8 @@
                 }
             }
 
-            return new ConcurrentDictionary<string, object>().GetEnumerator();
+            //-- LIBERA - MDEARMAN - 2015-10-08 - ITS 115318 - To match ASP.NET behavior, dictionaries should match keys case insensitively
+            return new ConcurrentDictionary<string, object>(StringComparer.InvariantCultureIgnoreCase).GetEnumerator();
         }
 
         #endregion

--- a/RedisSessionProviderUnitTests/RedisSessionStateItemCollectionTests/SingleThreadedTests.cs
+++ b/RedisSessionProviderUnitTests/RedisSessionStateItemCollectionTests/SingleThreadedTests.cs
@@ -40,6 +40,16 @@
             Assert.AreEqual("z", (string)this.items["c"]);
         }
 
+
+        [Test]
+        public void RedisItemsCollectionCaseInsensitiveAccessTest()
+        {
+            Assert.AreEqual("x", (string)this.items["A"]);
+            Assert.AreEqual("y", (string)this.items["B"]);
+            Assert.AreEqual("z", (string)this.items["C"]);
+        }
+
+
         [Test]
         public void RedisItemsCollectionAddTest()
         {


### PR DESCRIPTION
When switching from StateServer to RedisSessionProvider, I found that you're handling session keys case-sensitively, because you're using the default ConcurrentDictionary IStringEquality behavior.

MSDN docs don't specify, but at least based on Internet discussions: http://stackoverflow.com/questions/1731283/net-httpsessionstate-case-insensitivity that to match classic ASP behavior, session keys along with other ASP.NET collections are case-insensitive.
