### PR TITLE
Add Redis High Availability (Cluster/Sentinel) Feature

### DIFF
--- a/RedisSessionProvider/Config/RedisConnectionConfig.cs
+++ b/RedisSessionProvider/Config/RedisConnectionConfig.cs
@@ -32,6 +32,16 @@
         /// </summary>
         public static Func<HttpContextBase, KeyValuePair<string, ConfigurationOptions>> GetSERedisServerConfig = null;
 
+        //Redis High Availability (Cluster/Sentinel) Feature
+
+        /// <summary>
+        /// A delegate for returning a StackExchange.Redis.ConnectionMultiplexer instance which will allow
+        ///     application to pass an existing ConnectionMultiplexer for persisting session data. 
+        ///     Please assign a string key to your connection as well, in case you want to connect to multiple
+        ///     sets of Redis instances.
+        /// </summary>
+        public static Func<HttpContextBase, KeyValuePair<string, ConnectionMultiplexer>> GetSERedisServerConnection = null;
+
         /// <summary>
         /// Gets or sets a logging delegate that takes as input the server ip and port of the connection used as
         ///     a string and the number of total redis messages to it as a long

--- a/RedisSessionProvider/RedisSessionStateStoreProvider.cs
+++ b/RedisSessionProvider/RedisSessionStateStoreProvider.cs
@@ -471,6 +471,13 @@
                     RedisConnectionConfig.GetRedisServerAddress(context));
             }
 #pragma warning restore 0618
+            //Redis High Availability (Cluster/Sentinel) Feature
+            else if (RedisConnectionConfig.GetSERedisServerConnection != null)
+            {
+                KeyValuePair<string, ConnectionMultiplexer> connData =
+                   RedisConnectionConfig.GetSERedisServerConnection(context);
+                return new RedisConnectionWrapper(connData.Key, connData.Value);
+            }
 
             throw new ConfigurationErrorsException(
                 "RedisSessionProvider.Config.RedisConnectionWrapper.GetSERedisServerConfig delegate not set " +


### PR DESCRIPTION
Hi,

I have added a small feature wrt Redis High Availability scenario (Cluster/Sentinel), where ASP.NET applications that manage the StackExchange.Redis.ConnectionMultiplexer can pass that instance to the session provider. This will ensure that the session provider and application talk to the same redis instance (Master) in case of failovers. Let me know in case of any issues.